### PR TITLE
fix: verwijder brick/math uit require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
     "symfony/translation": "^8.0",
     "symfony/translation-contracts": "^3.5",
     "voku/portable-ascii": "^2.0.1",
-    "brick/math": "^0.12",
 
     "psr/cache": "^3.0.0",
     "psr/event-dispatcher": "^1.0.0",


### PR DESCRIPTION
Haalt `"brick/math": "^0.12"` uit `require`. Eén regel.

## Waarom

De pin blokkeert Laravel 13. Die vraagt `brick/math ^0.14.2 || ^0.15 || ^0.16 || ^0.17 || ^0.18`, dus elk project dat entrust gebruikt loopt vast:

```
mitchbred/entrust 2.5.8 requires brick/math ^0.12 -> found
brick/math[0.12.0, ..., 0.12.3] but it conflicts with your root
composer.json require (^0.14.2|^0.15|^0.16|^0.17|^0.18)
```

Sinds 2.5.8 staat de rest al goed op `illuminate/* ^13.0` en `symfony/* ^8.0`. Dit is wat er nog over is.

## Waarom het veilig is

`brick/math` wordt nergens gebruikt:

```
$ grep -rn "Brick" src/
$
```

De regel is een overblijfsel van het platslaan van de dependency-tree naar `composer.json`. Datzelfde geldt voor `psr/cache`, `voku/portable-ascii`, `symfony/polyfill-php80` en een handvol andere: het zijn transitieve dependencies die als directe require zijn beland. Die laat ik hier staan, want ze staan Laravel 13 niet in de weg. Alleen `brick/math` deed dat.

## Getest

Geverifieerd tegen parnassys-schoolkassa-backend via een composer `path`-repo naar een clone met deze wijziging:

```
- Upgrading laravel/framework  (v12.65.0 => v13.24.0)
- Upgrading brick/math         (0.12.3  => 0.18.0)
- Upgrading mitchbred/entrust  (2.5.7   => dev-main 0c87aed)
```

Resolvet schoon, geen conflicten.

Na merge is er een tag `2.5.9` nodig, want `main` en tag `2.5.8` wijzen nu naar dezelfde commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
