### PR TITLE
ci: lint via het composer-script in plaats van de phplint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,25 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-      - name: Checking PHP syntax error
-        uses: overtrue/phplint@9.8
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          path: .
-          options: --exclude=*.log
+          php-version: '8.4'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Checking PHP syntax error
+        run: composer run-script lint

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,6 @@
   },
   "scripts": {
     "test": "phpunit",
-    "lint": "phplint"
+    "lint": "phplint src tests rector.php"
   }
 }


### PR DESCRIPTION
`main` staat rood sinds 10:59 vandaag:

```
10:58:08  2d8c5c0  success   merge van #65
10:59:03  a907e8c  success
10:59:11  cf8da9c  success
10:59:21  e06c098  success
10:59:30  a25d898  failure   #60, overtrue/phplint 9.5 -> 9.8
```

## Wat er aan de hand is

De action print zelf dat alles in orde is en eindigt daarna alsnog met een non-zero exit, zonder annotatie:

```
PHPLint Console Application version 9.8.x-dev (e32dd35) by overtrue and contributors.
Runtime       : PHP 8.5.9
Configuration : No config file loaded

 [OK] 24 files
```

Twee dingen vallen op. De versie meldt zich als `9.8.x-dev`, want `@9.8` is een meebewegende branch en geen vaste release; de lint kan dus omvallen zonder dat er iets in deze repo verandert. En hij draait op PHP 8.5.9 in de container van de action, terwijl het pakket zelf `php: ^8.4` vraagt en `config.platform.php` op `8.4` zet.

## Wat deze PR doet

phplint draaien via `composer run-script lint`, op de versie die `require-dev` al pint en op dezelfde PHP-versie als de rest van de CI. Dat scheelt een third-party action in de keten en levert dezelfde 24 bestanden op.

Twee kleinere dingen mee:

De job heet nu `lint` in plaats van `build`. Dat beschrijft beter wat hij doet en botst niet meer met de matrix-jobs in `php.yml`. Branch protection op `main` heeft geen verplichte checks, dus de hernoeming blokkeert niets.

De trigger stond op kale `push`, waardoor hij ook draaide op branches zonder PR. Nu `main` plus pull requests, gelijk aan `php.yml`.

## Ook meegenomen: het lint-script zelf was kapot

#66 introduceerde `"lint": "phplint"` zonder pad. Kaal draait phplint over de hele map, inclusief `vendor`, en struikelt dan over de fixture met een opzettelijke syntaxfout in phplint zelf:

```
vendor/overtrue/phplint/tests/fixtures/syntax_error.php:4
 unexpected end of file in line 4
```

Nu `phplint src tests rector.php`. Die commit was bedoeld voor #66 maar kwam net na de merge binnen, dus hij ligt hier aan.

## Getest

Lokaal `composer run-script lint`: `[OK] 24 files`, exact hetzelfde aantal als de action rapporteerde. In CI op deze branch: `lint pass`, plus `Laravel ^12.0 pass` en `Laravel ^13.0 pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
